### PR TITLE
Patch Jenkinsfile to avoid race condition on multibuilds in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,28 +1,24 @@
 node ('centos8') {
-    def tag
-    stage('checkout') {
-        checkout scm
-        }
-       
-    stage('build') {
-        // build the container
-        sh 'podman build --format=docker -t ebi2gus $WORKSPACE'
-        }
+  def tag
 
-    stage('push') {
-      withCredentials([usernameColonPassword(credentialsId: '0f11d4d1-6557-423c-b5ae-693cc87f7b4b', variable: 'HUB_LOGIN')]) {
+  if (env.BRANCH_NAME == 'master') {
+    tag = "latest"
+  } else {
+    tag = "${env.BRANCH_NAME}"
+  }
 
-        // set master to latest (may be better ways to do this)
-        if (env.BRANCH_NAME == 'master') {
-           tag = "latest"
-         } else {
-           tag = "${env.BRANCH_NAME}"
-         }
+  stage('checkout') {
+    checkout scm
+  }
 
-        // push to dockerhub (for now)
-        sh "podman push --creds \"$HUB_LOGIN\" ebi2gus docker://docker.io/veupathdb/ebi2gus:${tag}"
-        }
-      }
+  stage('build') {
+    // build the container
+    sh "podman build --format=docker -t ebi2gus:${tag} $WORKSPACE"
+  }
 
+  stage('push') {
+    withCredentials([usernameColonPassword(credentialsId: '0f11d4d1-6557-423c-b5ae-693cc87f7b4b', variable: 'HUB_LOGIN')]) {
+      sh "podman push --creds \"$HUB_LOGIN\" ebi2gus:${tag} docker://docker.io/veupathdb/ebi2gus:${tag}"
     }
-
+  }
+}


### PR DESCRIPTION
Adds a tag to the local image name to avoid multiple builds overwriting the same image then attempting to publish that image resulting in images being published with incorrect version tags.
